### PR TITLE
FININFRA-03 - Adicionando PostgreSQL ao docker-compose

### DIFF
--- a/backend/PersonalFinanceProject/docker-compose.yml
+++ b/backend/PersonalFinanceProject/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: 
@@ -10,9 +8,31 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/personal_finance_db
+      - SPRING_DATASOURCE_USERNAME=postgres
+      - SPRING_DATASOURCE_PASSWORD=postgres
     networks:
       - app-network
+    depends_on:
+      - db
+
+  db:
+    image: postgres:latest
+    container_name: postgres_db
+    environment:
+      - POSTGRES_DB=personal_finance_db
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - app-network
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Inclui o postgresql no docker-compose para fechar a dockerização do backend, com o objetivo de auxiliar os desenvolvedores frontend a testarem a integração com o backend sem precisar baixar as tecnologias.